### PR TITLE
Make the tutorial look better on mobile

### DIFF
--- a/src/routes/tutorial/+page.svelte
+++ b/src/routes/tutorial/+page.svelte
@@ -7,14 +7,12 @@
 
 <div class="@container mx-auto flex flex-col p-4 text-center text-black">
 	<a href="/" class="-top-2.5 left-0.5 max-w-fit"><House /></a>
-	<h1 class="text-4xl md:text-5xl">Tutorial</h1>
-	<h2 class="my-4 text-2xl md:text-3xl">Learn how to play Reds!</h2>
+	<h1 class="text-3xl md:text-4xl lg:text-5xl">Tutorial</h1>
+	<h2 class="my-4 text-xl md:text-2xl lg:text-3xl">Learn how to play Reds!</h2>
 	<main class="@container/main gap-10">
-		<div
-			class="@container/step mx-auto flex w-3/5 flex-col items-center rounded-2xl bg-salmon p-10"
-		>
-			<h3 class="my-2 text-2xl whitespace-pre-wrap md:text-3xl">{stepJSON.title}</h3>
-			<p class="my-4 text-xl whitespace-pre-wrap md:text-2xl">
+		<div class="@container/step mr-2 ml-2 flex flex-col items-center rounded-2xl bg-salmon p-10">
+			<h3 class="my-2 text-xl whitespace-pre-wrap md:text-2xl lg:text-3xl">{stepJSON.title}</h3>
+			<p class="text-l my-4 whitespace-pre-wrap md:text-xl lg:text-2xl">
 				{stepJSON.content}
 			</p>
 		</div>

--- a/src/routes/tutorial/+page.svelte
+++ b/src/routes/tutorial/+page.svelte
@@ -9,30 +9,34 @@
 	<a href="/" class="-top-2.5 left-0.5 max-w-fit"><House /></a>
 	<h1 class="text-4xl md:text-5xl">Tutorial</h1>
 	<h2 class="my-4 text-2xl md:text-3xl">Learn how to play Reds!</h2>
-	<main class="@container/main flex flex-row justify-center gap-10">
-		<button
-			class="max-h-fit max-w-fit rounded-2xl bg-blue p-5 disabled:cursor-not-allowed disabled:bg-gray-700"
-			onclick={() => {
-				if (step > 1) step -= 1;
-			}}
-			disabled={step <= 1}
+	<main class="@container/main gap-10">
+		<div
+			class="@container/step mx-auto flex w-3/5 flex-col items-center rounded-2xl bg-salmon p-10"
 		>
-			<ArrowBigLeft size="30" />
-		</button>
-		<div class="@container/step flex w-3/5 flex-col items-center rounded-2xl bg-salmon p-10">
 			<h3 class="my-2 text-2xl whitespace-pre-wrap md:text-3xl">{stepJSON.title}</h3>
 			<p class="my-4 text-xl whitespace-pre-wrap md:text-2xl">
 				{stepJSON.content}
 			</p>
 		</div>
-		<button
-			class="max-width-fit max-h-fit rounded-2xl bg-blue p-5 disabled:cursor-not-allowed disabled:bg-gray-700"
-			onclick={() => {
-				if (step < steps.length) step += 1;
-			}}
-			disabled={step >= steps.length}
-		>
-			<ArrowBigRight size="30" />
-		</button>
+		<div class="@container/buttons mt-5 flex flex-row justify-center gap-5">
+			<button
+				class="max-h-fit max-w-fit rounded-2xl bg-blue p-5 disabled:cursor-not-allowed disabled:bg-gray-700"
+				onclick={() => {
+					if (step > 1) step -= 1;
+				}}
+				disabled={step <= 1}
+			>
+				<ArrowBigLeft size="30" />
+			</button>
+			<button
+				class="max-width-fit max-h-fit rounded-2xl bg-blue p-5 disabled:cursor-not-allowed disabled:bg-gray-700"
+				onclick={() => {
+					if (step < steps.length) step += 1;
+				}}
+				disabled={step >= steps.length}
+			>
+				<ArrowBigRight size="30" />
+			</button>
+		</div>
 	</main>
 </div>

--- a/src/routes/tutorial/+page.svelte
+++ b/src/routes/tutorial/+page.svelte
@@ -10,7 +10,7 @@
 	<h1 class="text-3xl md:text-4xl lg:text-5xl">Tutorial</h1>
 	<h2 class="my-4 text-xl md:text-2xl lg:text-3xl">Learn how to play Reds!</h2>
 	<main class="@container/main">
-		<div class="@container/step mr-2 ml-2 flex flex-col items-center rounded-2xl bg-salmon p-10">
+		<div class="@container/step mx-2 flex flex-col items-center rounded-2xl bg-salmon p-10">
 			<h3 class="my-2 text-xl whitespace-pre-wrap md:text-2xl lg:text-3xl">{stepJSON.title}</h3>
 			<p class="my-4 text-lg whitespace-pre-wrap md:text-xl lg:text-2xl">
 				{stepJSON.content}

--- a/src/routes/tutorial/+page.svelte
+++ b/src/routes/tutorial/+page.svelte
@@ -11,7 +11,7 @@
 	<h2 class="my-4 text-2xl md:text-3xl">Learn how to play Reds!</h2>
 	<main class="@container/main flex flex-row justify-center gap-10">
 		<button
-			class="max-w-fit rounded-2xl bg-blue p-5 disabled:cursor-not-allowed disabled:bg-gray-700"
+			class="max-h-fit max-w-fit rounded-2xl bg-blue p-5 disabled:cursor-not-allowed disabled:bg-gray-700"
 			onclick={() => {
 				if (step > 1) step -= 1;
 			}}
@@ -26,7 +26,7 @@
 			</p>
 		</div>
 		<button
-			class="max-width-fit rounded-2xl bg-blue p-5 disabled:cursor-not-allowed disabled:bg-gray-700"
+			class="max-width-fit max-h-fit rounded-2xl bg-blue p-5 disabled:cursor-not-allowed disabled:bg-gray-700"
 			onclick={() => {
 				if (step < steps.length) step += 1;
 			}}

--- a/src/routes/tutorial/+page.svelte
+++ b/src/routes/tutorial/+page.svelte
@@ -9,10 +9,10 @@
 	<a href="/" class="-top-2.5 left-0.5 max-w-fit"><House /></a>
 	<h1 class="text-3xl md:text-4xl lg:text-5xl">Tutorial</h1>
 	<h2 class="my-4 text-xl md:text-2xl lg:text-3xl">Learn how to play Reds!</h2>
-	<main class="@container/main gap-10">
+	<main class="@container/main">
 		<div class="@container/step mr-2 ml-2 flex flex-col items-center rounded-2xl bg-salmon p-10">
 			<h3 class="my-2 text-xl whitespace-pre-wrap md:text-2xl lg:text-3xl">{stepJSON.title}</h3>
-			<p class="text-l my-4 whitespace-pre-wrap md:text-xl lg:text-2xl">
+			<p class="my-4 text-lg whitespace-pre-wrap md:text-xl lg:text-2xl">
 				{stepJSON.content}
 			</p>
 		</div>
@@ -27,7 +27,7 @@
 				<ArrowBigLeft size="30" />
 			</button>
 			<button
-				class="max-width-fit max-h-fit rounded-2xl bg-blue p-5 disabled:cursor-not-allowed disabled:bg-gray-700"
+				class="max-h-fit max-w-fit rounded-2xl bg-blue p-5 disabled:cursor-not-allowed disabled:bg-gray-700"
 				onclick={() => {
 					if (step < steps.length) step += 1;
 				}}


### PR DESCRIPTION
It looks horrid at the moment. (Updated version posted in comment later)
<img width="1125" height="2436" alt="image" src="https://github.com/user-attachments/assets/96f5fc41-de7b-48fa-981e-31603aa025c0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned Tutorial page from a horizontal flow to a vertical, stacked layout with centred content.
  * Repositioned navigation buttons beneath the step panel in a dedicated buttons container; left/right buttons retained with disabled behaviour.
  * Refined header, title, subtitle and step typography scaling across breakpoints for improved readability and spacing.
  * Adjusted container margins and button sizing for consistent alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->